### PR TITLE
Make buildable with MinGW

### DIFF
--- a/mecab/src/common.h
+++ b/mecab/src/common.h
@@ -81,9 +81,15 @@
 #define EXIT_SUCCESS 0
 #endif
 
-#if defined(_WIN32) && !defined(__CYGWIN__)
-#define WPATH(path) (MeCab::Utf8ToWide(path).c_str())
+#ifdef _WIN32
+#ifdef __GNUC__
+#define WPATH_FORCE(path) (MeCab::Utf8ToWide(path).c_str())
+#define WPATH(path) (path)
 #else
+#define WPATH(path) WPATH_FORCE(path)
+#endif
+#else
+#define WPATH_FORCE(path) (path)
 #define WPATH(path) (path)
 #endif
 

--- a/mecab/src/mmap.h
+++ b/mecab/src/mmap.h
@@ -104,7 +104,7 @@ template <class T> class Mmap {
       CHECK_FALSE(false) << "unknown open mode:" << filename;
     }
 
-    hFile = ::CreateFileW(WPATH(filename), mode1, FILE_SHARE_READ, 0,
+    hFile = ::CreateFileW(WPATH_FORCE(filename), mode1, FILE_SHARE_READ, 0,
                           OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
     CHECK_FALSE(hFile != INVALID_HANDLE_VALUE)
         << "CreateFile() failed: " << filename;


### PR DESCRIPTION
We get build errors when we build with the following configure on
Debian GNU/Linux:

    % sudo apt-get install -y mingw-w64-x86-64-dev
    % ./configure --prefix=/tmp/mecab --host=x86_64-w64-mingw32

Here are build errors:

    In file included from tagger.cpp:15:0:
    stream_wrapper.h: In constructor 'MeCab::ostream_wrapper::ostream_wrapper(const char*)':
    stream_wrapper.h:49:46: error: no matching function for call to 'std::basic_ofstream<char>::basic_ofstream(const wchar_t*)'
           os_ = new std::ofstream(WPATH(filename));
                                                  ^
    stream_wrapper.h:49:46: note: candidates are:
    In file included from stream_wrapper.h:10:0,
                     from tagger.cpp:15:
    /usr/lib/gcc/x86_64-w64-mingw32/4.9-win32/include/c++/fstream:643:7: note: std::basic_ofstream<_CharT, _Traits>::basic_ofstream(const char*, std::ios_base::openmode) [with _CharT = char; _Traits = std::char_traits<char>; std::ios_base::openmode = std::_Ios_Openmode]
           basic_ofstream(const char* __s,
           ^
    /usr/lib/gcc/x86_64-w64-mingw32/4.9-win32/include/c++/fstream:643:7: note:   no known conversion for argument 1 from 'const wchar_t*' to 'const char*'
    /usr/lib/gcc/x86_64-w64-mingw32/4.9-win32/include/c++/fstream:628:7: note: std::basic_ofstream<_CharT, _Traits>::basic_ofstream() [with _CharT = char; _Traits = std::char_traits<char>]
           basic_ofstream(): __ostream_type(), _M_filebuf()
           ^
    /usr/lib/gcc/x86_64-w64-mingw32/4.9-win32/include/c++/fstream:628:7: note:   candidate expects 0 arguments, 1 provided
    /usr/lib/gcc/x86_64-w64-mingw32/4.9-win32/include/c++/fstream:602:11: note: std::basic_ofstream<char>::basic_ofstream(const std::basic_ofstream<char>&)
         class basic_ofstream : public basic_ostream<_CharT,_Traits>
               ^
    /usr/lib/gcc/x86_64-w64-mingw32/4.9-win32/include/c++/fstream:602:11: note:   no known conversion for argument 1 from 'const wchar_t*' to 'const std::basic_ofstream<char>&'

These errors are caused because MinGW doesn't support wide stream
support streams. See also: http://www.mingw.org/wiki/wide_characters

WPATH_FORCE() is just for CreateFileW(). MinGW doesn't support wide
stream support streams but supports CreateFileW().