### PR TITLE
fix SWIG preprocessor typos in mecab.h

### DIFF
--- a/mecab/src/mecab.h
+++ b/mecab/src/mecab.h
@@ -1122,7 +1122,7 @@ public:
 
   virtual ~Model() {}
 
-#ifndef SIWG
+#ifndef SWIG
   /**
    * Factory method to create a new Model with a specified main's argc/argv-style parameters.
    * Return NULL if new model cannot be initialized. Use MeCab::getLastError() to obtain the
@@ -1411,7 +1411,7 @@ public:
 
   virtual ~Tagger() {}
 
-#ifndef SIWG
+#ifndef SWIG
   /**
    * Factory method to create a new Tagger with a specified main's argc/argv-style parameters.
    * Return NULL if new model cannot be initialized. Use MeCab::getLastError() to obtain the


### PR DESCRIPTION
Without this fix, trying to build mecab for Windows x64 and then mecab-python for x64 python (2.7.10) results in errors: "fatal error LNK1120: 11 unresolved externals".

Reference for building on Windows 7 x64 and python 2.7 x64:
http://pop365.cocolog-nifty.com/blog/2015/03/windows-64bit-m.html
http://orion.bluememe.jp/2011/09/windows-64bitmecab.html

I haven't checked if similar errors occur on Windows x86.