### PR TITLE
Fix missing returncode check of loading rcfile path for Windows.

### DIFF
--- a/mecab/src/utils.cpp
+++ b/mecab/src/utils.cpp
@@ -330,23 +330,24 @@ bool load_dictionary_resource(Param *param) {
   scoped_fixed_array<wchar_t, BUF_SIZE> v;
   DWORD vt;
   DWORD size = v.size() * sizeof(v[0]);
+  DWORD qvres;
 
   if (rcfile.empty()) {
     ::RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"software\\mecab", 0, KEY_READ, &hKey);
-    ::RegQueryValueExW(hKey, L"mecabrc", 0, &vt,
+    qvres = ::RegQueryValueExW(hKey, L"mecabrc", 0, &vt,
                        reinterpret_cast<BYTE *>(v.get()), &size);
     ::RegCloseKey(hKey);
-    if (vt == REG_SZ) {
+    if (qvres == ERROR_SUCCESS && vt == REG_SZ) {
       rcfile = WideToUtf8(v.get());
     }
   }
 
   if (rcfile.empty()) {
     ::RegOpenKeyExW(HKEY_CURRENT_USER, L"software\\mecab", 0, KEY_READ, &hKey);
-    ::RegQueryValueExW(hKey, L"mecabrc", 0, &vt,
+    qvres = ::RegQueryValueExW(hKey, L"mecabrc", 0, &vt,
                        reinterpret_cast<BYTE *>(v.get()), &size);
     ::RegCloseKey(hKey);
-    if (vt == REG_SZ) {
+    if (qvres == ERROR_SUCCESS && vt == REG_SZ) {
       rcfile = WideToUtf8(v.get());
     }
   }


### PR DESCRIPTION
`RegQueryValueExW` needs returncode check.

When `(HKLM|HKCU)\software` has no key `mecab` , 
`RegQueryValueExW` does not change value of `vt` (remain undefined).

This pull request maybe related #21.
I met with this bug. (MeCab 64bit compiled from source, Miniconda Python 64bit on Windows 10)