### PR TITLE
Fix typo: destory -> destroy

### DIFF
--- a/libmecab.html
+++ b/libmecab.html
@@ -421,7 +421,7 @@ int main (int argc, char **argv)  {
 
   mecab_destroy(mecab);
   mecab_lattice_destroy(lattice);
-  mecab_model_destory(model);
+  mecab_model_destroy(model);
 
   return 0;
 }

--- a/mecab/doc/libmecab.html
+++ b/mecab/doc/libmecab.html
@@ -421,7 +421,7 @@ int main (int argc, char **argv)  {
 
   mecab_destroy(mecab);
   mecab_lattice_destroy(lattice);
-  mecab_model_destory(model);
+  mecab_model_destroy(model);
 
   return 0;
 }


### PR DESCRIPTION
This typo has led to confusing linker error regarding undefined reference to `mecab_model_destory`.