### PR TITLE
fix: use correct libexecdir

### DIFF
--- a/mecab/mecab-config.in
+++ b/mecab/mecab-config.in
@@ -107,7 +107,7 @@ while test $# -gt 0; do
 	;;
 
     --libexecdir)
-       	echo @prefix@/libexec/mecab
+       	echo @libexecdir@/mecab
        	;;
 	
     --sysconfdir)


### PR DESCRIPTION
I built the tool with `--libexecdir=/usr/lib` flag, but `mecab-config --libexecdir` still output `/usr/libexec/mecab` which is not as expected.

Other people may also occurred the problem, like this one: https://www.komee.org/entry/2018/02/28/120128

@taku910 