### PR TITLE
Fix runtime error for python3

### DIFF
--- a/mecab/python/setup.py
+++ b/mecab/python/setup.py
@@ -7,7 +7,7 @@ def cmd1(str):
     return os.popen(str).readlines()[0][:-1]
 
 def cmd2(str):
-    return string.split (cmd1(str))
+    return cmd1(str).split()
 
 setup(name = "mecab-python",
 	version = cmd1("mecab-config --version"),


### PR DESCRIPTION
fixed `AttributeError: module 'string' has no attribute 'split'` for python3.