### PR TITLE
Fix stringop-truncation warnings

### DIFF
--- a/mecab/src/dictionary_rewriter.cpp
+++ b/mecab/src/dictionary_rewriter.cpp
@@ -44,7 +44,7 @@ bool match_rewrite_pattern(const char *pat,
     scoped_fixed_array<char, BUF_SIZE> buf;
     scoped_fixed_array<char *, BUF_SIZE> col;
     CHECK_DIE(len < buf.size() - 3) << "too long parameter";
-    std::strncpy(buf.get(), pat + 1, buf.size());
+    std::strncpy(buf.get(), pat + 1, buf.size() - 1u);
     buf[len-2] = '\0';
     const size_t n = tokenize(buf.get(), "|", col.get(), col.size());
     CHECK_DIE(n < col.size()) << "too long OR nodes";
@@ -64,10 +64,10 @@ bool RewritePattern::set_pattern(const char *src,
   spat_.clear();
   dpat_.clear();
 
-  std::strncpy(buf.get(), src, buf.size());
+  std::strncpy(buf.get(), src, buf.size() - 1u);
   tokenizeCSV(buf.get(), back_inserter(spat_), 512);
 
-  std::strncpy(buf.get(), dst, buf.size());
+  std::strncpy(buf.get(), dst, buf.size() - 1u);
   tokenizeCSV(buf.get(), back_inserter(dpat_), 512);
 
   return (spat_.size() && dpat_.size());
@@ -166,7 +166,7 @@ bool DictionaryRewriter::rewrite(const std::string &feature,
   scoped_fixed_array<char, BUF_SIZE> buf;
   scoped_fixed_array<char *, BUF_SIZE> col;
   CHECK_DIE(feature.size() < buf.size() - 1) << "too long feature";
-  std::strncpy(buf.get(), feature.c_str(), buf.size() - 1);
+  std::strncpy(buf.get(), feature.c_str(), buf.size() - 1u);
   const size_t n = tokenizeCSV(buf.get(), col.get(), col.size());
   CHECK_DIE(n < col.size()) << "too long CSV entities";
   return (unigram_rewrite_.rewrite(n, const_cast<const char **>(col.get()),

--- a/mecab/src/feature_index.cpp
+++ b/mecab/src/feature_index.cpp
@@ -334,7 +334,7 @@ bool FeatureIndex::buildUnigramFeature(LearnerPath *path,
   scoped_fixed_array<char *, POSSIZE> F;
 
   feature_.clear();
-  std::strncpy(ubuf.get(), ufeature, ubuf.size());
+  std::strncpy(ubuf.get(), ufeature, ubuf.size() - 1u);
   const size_t usize = tokenizeCSV(ubuf.get(), F.get(), F.size());
 
   for (std::vector<const char*>::const_iterator it = unigram_templs_.begin();
@@ -386,8 +386,8 @@ bool FeatureIndex::buildBigramFeature(LearnerPath *path,
   scoped_fixed_array<char *, POSSIZE> L;
 
   feature_.clear();
-  std::strncpy(lbuf.get(),  rfeature, lbuf.size());
-  std::strncpy(rbuf.get(),  lfeature, rbuf.size());
+  std::strncpy(lbuf.get(),  rfeature, lbuf.size() - 1u);
+  std::strncpy(rbuf.get(),  lfeature, rbuf.size() - 1u);
 
   const size_t lsize = tokenizeCSV(lbuf.get(), L.get(), L.size());
   const size_t rsize = tokenizeCSV(rbuf.get(), R.get(), R.size());

--- a/mecab/src/param.cpp
+++ b/mecab/src/param.cpp
@@ -191,7 +191,7 @@ void Param::clear() {
 
 bool Param::open(const char *arg, const Option *opts) {
   scoped_fixed_array<char, BUF_SIZE> str;
-  std::strncpy(str.get(), arg, str.size());
+  std::strncpy(str.get(), arg, str.size() - 1u);
   char* ptr[64];
   unsigned int size = 1;
   ptr[0] = const_cast<char*>(PACKAGE);

--- a/mecab/src/tokenizer.cpp
+++ b/mecab/src/tokenizer.cpp
@@ -120,7 +120,7 @@ bool Tokenizer<N, P>::open(const Param &param) {
   if (!userdic.empty()) {
     scoped_fixed_array<char, BUF_SIZE> buf;
     scoped_fixed_array<char *, BUF_SIZE> dicfile;
-    std::strncpy(buf.get(), userdic.c_str(), buf.size());
+    std::strncpy(buf.get(), userdic.c_str(), buf.size() - 1u);
     const size_t n = tokenizeCSV(buf.get(), dicfile.get(), dicfile.size());
     for (size_t i = 0; i < n; ++i) {
       Dictionary *d = new Dictionary;
@@ -190,8 +190,8 @@ inline bool partial_match(const char *f1, const char *f2) {
   scoped_fixed_array<char *, 64> c1;
   scoped_fixed_array<char *, 64> c2;
 
-  std::strncpy(buf1.get(), f1, buf1.size());
-  std::strncpy(buf2.get(), f2, buf2.size());
+  std::strncpy(buf1.get(), f1, buf1.size() - 1u);
+  std::strncpy(buf2.get(), f2, buf2.size() - 1u);
 
   const size_t n1 = tokenizeCSV(buf1.get(), c1.get(), c1.size());
   const size_t n2 = tokenizeCSV(buf2.get(), c2.get(), c2.size());

--- a/mecab/src/writer.cpp
+++ b/mecab/src/writer.cpp
@@ -349,7 +349,7 @@ bool Writer::writeNode(Lattice *lattice,
               return false;
             }
             if (!psize) {
-              std::strncpy(buf.get(), node->feature, buf.size());
+              std::strncpy(buf.get(), node->feature, buf.size() - 1u);
               psize = tokenizeCSV(buf.get(), ptr.get(), ptr.size());
             }
 


### PR DESCRIPTION
Identified by modern gcc.

Issued on invocations of `strncpy` that could result in C-strings
which are not null-terminated. Fixed by copying fewer chars.