### PR TITLE
Update dictionary.cpp (maybe related #10)

### DIFF
--- a/mecab/src/dictionary.cpp
+++ b/mecab/src/dictionary.cpp
@@ -179,8 +179,8 @@ bool Dictionary::assignUserDictionaryCosts(
 
   cid.open(left_id_file.c_str(),
            right_id_file.c_str(), &config_iconv);
-  CHECK_DIE(cid.left_size()  == matrix.left_size() &&
-            cid.right_size() == matrix.right_size())
+  CHECK_DIE(cid.left_size()  == matrix.right_size() &&
+            cid.right_size() == matrix.left_size())
       << "Context ID files("
       << left_id_file
       << " or "
@@ -352,8 +352,8 @@ bool Dictionary::compile(const Param &param,
           cid.reset(new ContextID);
           cid->open(left_id_file.c_str(),
                     right_id_file.c_str(), &config_iconv);
-          CHECK_DIE(cid->left_size()  == matrix.left_size() &&
-                    cid->right_size() == matrix.right_size())
+          CHECK_DIE(cid->left_size()  == matrix.right_size() &&
+                    cid->right_size() == matrix.left_size())
               << "Context ID files("
               << left_id_file
               << " or "


### PR DESCRIPTION
ContextID and Matrix left and right sizes are probably reversed.
So if the right-id and left-id sizes are different, an error will result.

taku910/mecab/issues/10