### PR TITLE
src/dictionary.cpp: dropping usage of binary_function

### DIFF
--- a/mecab/src/dictionary.cpp
+++ b/mecab/src/dictionary.cpp
@@ -65,7 +65,11 @@ int progress_bar_darts(size_t current, size_t total) {
 }
 
 template <typename T1, typename T2>
-struct pair_1st_cmp: public std::binary_function<bool, T1, T2> {
+struct pair_1st_cmp {
+  public:
+  using first_argument_type = bool;
+  using second_argument_type = T1;
+  using result_type = T2;
   bool operator()(const std::pair<T1, T2> &x1,
                   const std::pair<T1, T2> &x2)  {
     return x1.first < x2.first;


### PR DESCRIPTION
According to
https://en.cppreference.com/w/cpp/utility/functional/binary_function, binary_function has been dropped in C++17